### PR TITLE
fix. DeployConfigur for GoogleAppEngine

### DIFF
--- a/scrapy/src/app.yaml
+++ b/scrapy/src/app.yaml
@@ -1,5 +1,3 @@
-application: opendata-platform
-version: 1
 runtime: go115
 api_version: go1
 


### PR DESCRIPTION
app.yamlの仕様変更に伴い、applicationとversion の項目は削除する

```
ERROR: (gcloud.app.deploy) The [application] field is specified in file [/workspace/opendata-platform/scrapy/src/app.yaml]. This field is not used by gcloud and must be removed. Project name should instead be specified either by `gcloud config set project MY_PROJECT` or by setting the `--project` flag on individual command executions.
Finished Step #1
```