### PR TITLE
fix. DeployConfigur for GoogleAppEngine

### DIFF
--- a/scrapy/src/app.yaml
+++ b/scrapy/src/app.yaml
@@ -1,5 +1,4 @@
-runtime: go115
-api_version: go1
+runtime: go116
 
 handlers:
 - url: /.*


### PR DESCRIPTION
app.yaml から api_version の項目は削除

```
Step #1: ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: Error(s) encountered validating runtime. "api_version" field is not allowed in runtime go115.
```